### PR TITLE
Fixes to work with current Connect and Comprehend default behaviour

### DIFF
--- a/functions/loadTranscript/loadTranscript.py
+++ b/functions/loadTranscript/loadTranscript.py
@@ -16,28 +16,28 @@ def lambda_handler(event, context):
         source_key = event.get("source_key")
         dest_bucket = source_bucket
         dest_key = source_key
-        
-         # get transcript & metadata from S3 object
+
+        # get transcript & metadata from S3 object
         transcript_s3_object = s3_resource.Object(source_bucket, source_key)
         transcript = json.loads(transcript_s3_object.get()['Body'].read().decode('utf-8'))
-        
+
         # Create backup of original transcript
         s3_client.copy_object(Bucket=source_bucket,Key=source_key+'.backup',CopySource=source_bucket+'/'+source_key)
-        
+
         # load each transcript item that needs to be redacted in an array
         transcript_content = {'Content':[]}
         for item in transcript.get("Transcript"):
-            if (item.get("ContentType") == "text/plain"):
+            if (item.get("ContentType") in ["text/plain", "text/markdown"]):
                 transcript_content.get('Content').append(item.get("Content"))
-        
+
         # upload content array to be redacted
         redaction_source_key = source_key + '.redaction_source'
         redaction_source_object = s3_resource.Object(source_bucket, redaction_source_key)
         redaction_source_object.put(Body=json.dumps(transcript_content))
-        
+
         # Delete source transcript to remove Connect UI access to unredacted transcripts
         s3_resource.Object(source_bucket,source_key).delete()
-        
+
         step_function_output = {
             "redaction_source_key": redaction_source_key,
             "destination_bucket": dest_bucket,

--- a/functions/storeRedactedTranscript/storeRedactedTranscript.py
+++ b/functions/storeRedactedTranscript/storeRedactedTranscript.py
@@ -50,7 +50,7 @@ def lambda_handler(event,context):
         # Replace original transcript content if its plain/text with redacted content
         for transcript in source_content.get('Transcript'):
             pii_item = transcript
-            if(transcript.get('ContentType') == 'text/plain'):
+            if(transcript.get('ContentType') in ['text/plain','text/markdown']):
                 #Replace transcript content with redacted content
                 pii_item['Content'] = redacted_content.pop(0)
             pii_transcript.get("Transcript").append(pii_item)

--- a/functions/storeRedactedTranscript/storeRedactedTranscript.py
+++ b/functions/storeRedactedTranscript/storeRedactedTranscript.py
@@ -68,7 +68,7 @@ def lambda_handler(event,context):
         
         # Clean up unwanted files
         s3_resource.Object(source_bucket, redacted_content_out_key).delete()
-        s3_resource.Object(source_bucket, redacted_content_key + '.write_access_check_file.temp').delete()
+        s3_resource.Object(source_bucket, source_key + '.redactedoutput/.write_access_check_file.temp').delete()
         s3_resource.Object(source_bucket, redaction_source_key).delete()
         
         return "Successfully redacted transcripts!"


### PR DESCRIPTION
- Connect chats now support rich text by default using the pre-built chat widget. Extract text/markdown content for redaction alongside text/plain.
- Fix cleanup of Comprehend write check to leave S3 bucket in a neat state